### PR TITLE
Basic media view 

### DIFF
--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -13,6 +13,7 @@ import '../util/intl.dart';
 import '../util/text_color.dart';
 import '../widgets/badge.dart';
 import '../widgets/bottom_modal.dart';
+import '../widgets/fullscreenable_image.dart';
 import '../widgets/markdown_text.dart';
 
 class CommunityPage extends HookWidget {
@@ -251,14 +252,17 @@ class _CommunityOverview extends StatelessWidget {
               Container(
                 width: 83,
                 height: 83,
-                child: CachedNetworkImage(
-                  imageUrl: community.icon,
-                  imageBuilder: (context, imageProvider) => Container(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      image: DecorationImage(
-                        fit: BoxFit.cover,
-                        image: imageProvider,
+                child: FullscreenableImage(
+                  url: community.icon,
+                  child: CachedNetworkImage(
+                    imageUrl: community.icon,
+                    imageBuilder: (context, imageProvider) => Container(
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        image: DecorationImage(
+                          fit: BoxFit.cover,
+                          image: imageProvider,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -265,6 +265,7 @@ class _CommunityOverview extends StatelessWidget {
                         ),
                       ),
                     ),
+                    errorWidget: (_, __, ___) => Icon(Icons.warning),
                   ),
                 ),
               ),
@@ -277,7 +278,10 @@ class _CommunityOverview extends StatelessWidget {
       if (community.banner != null)
         FullscreenableImage(
           url: community.banner,
-          child: CachedNetworkImage(imageUrl: community.banner),
+          child: CachedNetworkImage(
+            imageUrl: community.banner,
+            errorWidget: (_, __, ___) => Container(),
+          ),
         ),
       SafeArea(
         child: Padding(

--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -275,7 +275,10 @@ class _CommunityOverview extends StatelessWidget {
 
     return Stack(children: [
       if (community.banner != null)
-        CachedNetworkImage(imageUrl: community.banner),
+        FullscreenableImage(
+          url: community.banner,
+          child: CachedNetworkImage(imageUrl: community.banner),
+        ),
       SafeArea(
         child: Padding(
           padding: const EdgeInsets.only(top: 45),

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -11,6 +11,7 @@ import '../util/goto.dart';
 import '../util/text_color.dart';
 import '../widgets/badge.dart';
 import '../widgets/bottom_modal.dart';
+import '../widgets/fullscreenable_image.dart';
 import '../widgets/markdown_text.dart';
 import 'communities_list.dart';
 import 'users_list.dart';
@@ -166,10 +167,13 @@ class InstancePage extends HookWidget {
                         children: [
                           Padding(
                             padding: const EdgeInsets.only(top: 40),
-                            child: CachedNetworkImage(
-                                width: 100,
-                                height: 100,
-                                imageUrl: site.site.icon),
+                            child: FullscreenableImage(
+                              url: site.site.icon,
+                              child: CachedNetworkImage(
+                                  width: 100,
+                                  height: 100,
+                                  imageUrl: site.site.icon),
+                            ),
                           ),
                           Text(site.site.name,
                               style: theme.textTheme.headline6),

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -160,7 +160,10 @@ class InstancePage extends HookWidget {
               flexibleSpace: FlexibleSpaceBar(
                 background: Stack(children: [
                   if (site.site.banner != null)
-                    CachedNetworkImage(imageUrl: site.site.banner),
+                    FullscreenableImage(
+                      url: site.site.banner,
+                      child: CachedNetworkImage(imageUrl: site.site.banner),
+                    ),
                   SafeArea(
                     child: Center(
                       child: Column(

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -162,7 +162,10 @@ class InstancePage extends HookWidget {
                   if (site.site.banner != null)
                     FullscreenableImage(
                       url: site.site.banner,
-                      child: CachedNetworkImage(imageUrl: site.site.banner),
+                      child: CachedNetworkImage(
+                        imageUrl: site.site.banner,
+                        errorWidget: (_, __, ___) => Container(),
+                      ),
                     ),
                   SafeArea(
                     child: Center(
@@ -173,9 +176,12 @@ class InstancePage extends HookWidget {
                             child: FullscreenableImage(
                               url: site.site.icon,
                               child: CachedNetworkImage(
-                                  width: 100,
-                                  height: 100,
-                                  imageUrl: site.site.icon),
+                                width: 100,
+                                height: 100,
+                                imageUrl: site.site.icon,
+                                errorWidget: (_, __, ___) =>
+                                    Icon(Icons.warning),
+                              ),
                             ),
                           ),
                           Text(site.site.name,
@@ -332,6 +338,8 @@ class _AboutTab extends HookWidget {
                             height: 50,
                             width: 50,
                             imageUrl: e.icon,
+                            errorWidget: (_, __, ___) =>
+                                SizedBox(width: 50, height: 50),
                             imageBuilder: (context, imageProvider) => Container(
                                   decoration: BoxDecoration(
                                     shape: BoxShape.circle,
@@ -380,6 +388,8 @@ class _AboutTab extends HookWidget {
                           height: 50,
                           width: 50,
                           imageUrl: e.avatar,
+                          errorWidget: (_, __, ___) =>
+                              SizedBox(width: 50, height: 50),
                           imageBuilder: (context, imageProvider) => Container(
                                 decoration: BoxDecoration(
                                   shape: BoxShape.circle,

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -26,6 +26,7 @@ class MediaViewPage extends HookWidget {
       } else {
         SystemChrome.setEnabledSystemUIOverlays([]);
       }
+      return null;
     }, [showButtons.value]);
 
     useEffect(

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -5,12 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:photo_view/photo_view.dart';
 
-import 'bottom_modal.dart';
+import '../widgets/bottom_modal.dart';
 
-class MediaView extends HookWidget {
+class MediaViewPage extends HookWidget {
   final String url;
 
-  const MediaView(this.url);
+  const MediaViewPage(this.url);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -26,11 +26,14 @@ class MediaViewPage extends HookWidget {
       } else {
         SystemChrome.setEnabledSystemUIOverlays([]);
       }
-      return () => SystemChrome.setEnabledSystemUIOverlays([
-            SystemUiOverlay.bottom,
-            SystemUiOverlay.top,
-          ]);
-    });
+    }, [showButtons.value]);
+
+    useEffect(
+        () => () => SystemChrome.setEnabledSystemUIOverlays([
+              SystemUiOverlay.bottom,
+              SystemUiOverlay.top,
+            ]),
+        []);
 
     share() {
       showModalBottomSheet(

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -17,19 +17,20 @@ class MediaViewPage extends HookWidget {
     final showButtons = useState(true);
     final isZoomedOut = useState(true);
 
-    useEffect(() => () => SystemChrome.setEnabledSystemUIOverlays([
+    useEffect(() {
+      if (showButtons.value) {
+        SystemChrome.setEnabledSystemUIOverlays([
           SystemUiOverlay.bottom,
           SystemUiOverlay.top,
-        ]));
-
-    if (showButtons.value) {
-      SystemChrome.setEnabledSystemUIOverlays([
-        SystemUiOverlay.bottom,
-        SystemUiOverlay.top,
-      ]);
-    } else {
-      SystemChrome.setEnabledSystemUIOverlays([]);
-    }
+        ]);
+      } else {
+        SystemChrome.setEnabledSystemUIOverlays([]);
+      }
+      return () => SystemChrome.setEnabledSystemUIOverlays([
+            SystemUiOverlay.bottom,
+            SystemUiOverlay.top,
+          ]);
+    });
 
     share() {
       showModalBottomSheet(

--- a/lib/pages/users_list.dart
+++ b/lib/pages/users_list.dart
@@ -48,6 +48,8 @@ class UsersListPage extends StatelessWidget {
                     height: 50,
                     width: 50,
                     imageUrl: users[i].avatar,
+                    errorWidget: (_, __, ___) =>
+                        SizedBox(height: 50, width: 50),
                     imageBuilder: (context, imageProvider) => Container(
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -200,6 +200,7 @@ class Comment extends StatelessWidget {
                             ),
                           ),
                         ),
+                        errorWidget: (_, __, ___) => Container(),
                       ),
                     ),
                   ),

--- a/lib/widgets/fullscreenable_image.dart
+++ b/lib/widgets/fullscreenable_image.dart
@@ -6,16 +6,22 @@ class FullscreenableImage extends StatelessWidget {
   final String url;
   final Widget child;
 
-  const FullscreenableImage({Key key, this.url, this.child}) : super(key: key);
+  const FullscreenableImage({
+    Key key,
+    @required this.url,
+    @required this.child,
+  }) : super(key: key);
+
+  _onTap(BuildContext c) {
+    Navigator.of(c).push(MaterialPageRoute(
+      builder: (context) => MediaViewPage(url),
+    ));
+  }
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () {
-        Navigator.of(context).push(MaterialPageRoute(
-          builder: (context) => MediaViewPage(url),
-        ));
-      },
+      onTap: () => _onTap(context),
       child: Hero(
         tag: url,
         child: child,

--- a/lib/widgets/fullscreenable_image.dart
+++ b/lib/widgets/fullscreenable_image.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../pages/media_view.dart';
+
+class FullscreenableImage extends StatelessWidget {
+  final String url;
+  final Widget child;
+
+  const FullscreenableImage({Key key, this.url, this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        Navigator.of(context).push(MaterialPageRoute(
+          builder: (context) => MediaViewPage(url),
+        ));
+      },
+      child: Hero(
+        tag: url,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/widgets/fullscreenable_image.dart
+++ b/lib/widgets/fullscreenable_image.dart
@@ -19,13 +19,11 @@ class FullscreenableImage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: () => _onTap(context),
-      child: Hero(
-        tag: url,
-        child: child,
-      ),
-    );
-  }
+  Widget build(BuildContext context) => InkWell(
+        onTap: () => _onTap(context),
+        child: Hero(
+          tag: url,
+          child: child,
+        ),
+      );
 }

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:lemmur/pages/media_view.dart';
 import 'package:markdown/markdown.dart' as md;
 
 import '../url_launcher.dart';
@@ -24,13 +25,20 @@ class MarkdownText extends StatelessWidget {
                     ),
                   )));
         },
-        imageBuilder: (uri, title, alt) => CachedNetworkImage(
-          imageUrl: uri.toString(),
-          errorWidget: (context, url, error) => Row(
-            children: [
-              Icon(Icons.warning),
-              Text("couldn't load image, ${error.toString()}")
-            ],
+        imageBuilder: (uri, title, alt) => InkWell(
+          onTap: () {
+            Navigator.of(context).push(MaterialPageRoute(
+              builder: (context) => MediaViewPage(uri.toString()),
+            ));
+          },
+          child: CachedNetworkImage(
+            imageUrl: uri.toString(),
+            errorWidget: (context, url, error) => Row(
+              children: [
+                Icon(Icons.warning),
+                Text("couldn't load image, ${error.toString()}")
+              ],
+            ),
           ),
         ),
       );

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
-import '../pages/media_view.dart';
 import '../url_launcher.dart';
 import 'fullscreenable_image.dart';
 
@@ -28,22 +27,15 @@ class MarkdownText extends StatelessWidget {
                     ),
                   )));
         },
-        imageBuilder: (uri, title, alt) => InkWell(
-          onTap: () {
-            Navigator.of(context).push(MaterialPageRoute(
-              builder: (context) => MediaViewPage(uri.toString()),
-            ));
-          },
-          child: FullscreenableImage(
-            url: uri.toString(),
-            child: CachedNetworkImage(
-              imageUrl: uri.toString(),
-              errorWidget: (context, url, error) => Row(
-                children: [
-                  Icon(Icons.warning),
-                  Text("couldn't load image, ${error.toString()}")
-                ],
-              ),
+        imageBuilder: (uri, title, alt) => FullscreenableImage(
+          url: uri.toString(),
+          child: CachedNetworkImage(
+            imageUrl: uri.toString(),
+            errorWidget: (context, url, error) => Row(
+              children: [
+                Icon(Icons.warning),
+                Text("couldn't load image, ${error.toString()}")
+              ],
             ),
           ),
         ),

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -1,9 +1,9 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:lemmur/pages/media_view.dart';
 import 'package:markdown/markdown.dart' as md;
 
+import '../pages/media_view.dart';
 import '../url_launcher.dart';
 import 'fullscreenable_image.dart';
 

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -5,6 +5,7 @@ import 'package:lemmur/pages/media_view.dart';
 import 'package:markdown/markdown.dart' as md;
 
 import '../url_launcher.dart';
+import 'fullscreenable_image.dart';
 
 class MarkdownText extends StatelessWidget {
   final String text;
@@ -31,13 +32,16 @@ class MarkdownText extends StatelessWidget {
               builder: (context) => MediaViewPage(uri.toString()),
             ));
           },
-          child: CachedNetworkImage(
-            imageUrl: uri.toString(),
-            errorWidget: (context, url, error) => Row(
-              children: [
-                Icon(Icons.warning),
-                Text("couldn't load image, ${error.toString()}")
-              ],
+          child: FullscreenableImage(
+            url: uri.toString(),
+            child: CachedNetworkImage(
+              imageUrl: uri.toString(),
+              errorWidget: (context, url, error) => Row(
+                children: [
+                  Icon(Icons.warning),
+                  Text("couldn't load image, ${error.toString()}")
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/widgets/media_view.dart
+++ b/lib/widgets/media_view.dart
@@ -28,13 +28,12 @@ class MediaView extends HookWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor:
-            showButtons.value ? Colors.black38 : Colors.transparent,
-        shadowColor: Colors.transparent,
-        leading: showButtons.value ? CloseButton() : Container(),
-        actions: showButtons.value
-            ? [
+      appBar: showButtons.value
+          ? AppBar(
+              backgroundColor: Colors.black38,
+              shadowColor: Colors.transparent,
+              leading: CloseButton(),
+              actions: [
                 IconButton(
                   icon: Icon(Icons.share),
                   tooltip: 'share',
@@ -45,9 +44,9 @@ class MediaView extends HookWidget {
                   tooltip: 'download',
                   onPressed: () {},
                 ),
-              ]
-            : null,
-      ),
+              ],
+            )
+          : null,
       extendBodyBehindAppBar: true,
       body: GestureDetector(
         onTapUp: (details) => showButtons.value = !showButtons.value,

--- a/lib/widgets/media_view.dart
+++ b/lib/widgets/media_view.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:photo_view/photo_view.dart';
 
@@ -11,6 +12,20 @@ class MediaView extends HookWidget {
   @override
   Widget build(BuildContext context) {
     var showButtons = useState(true);
+
+    useEffect(() => () => SystemChrome.setEnabledSystemUIOverlays([
+          SystemUiOverlay.bottom,
+          SystemUiOverlay.top,
+        ]));
+
+    if (showButtons.value) {
+      SystemChrome.setEnabledSystemUIOverlays([
+        SystemUiOverlay.bottom,
+        SystemUiOverlay.top,
+      ]);
+    } else {
+      SystemChrome.setEnabledSystemUIOverlays([]);
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/widgets/media_view.dart
+++ b/lib/widgets/media_view.dart
@@ -14,7 +14,8 @@ class MediaView extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    var showButtons = useState(true);
+    final showButtons = useState(true);
+    final isZoomedOut = useState(true);
 
     useEffect(() => () => SystemChrome.setEnabledSystemUIOverlays([
           SystemUiOverlay.bottom,
@@ -60,6 +61,8 @@ class MediaView extends HookWidget {
     }
 
     return Scaffold(
+      extendBodyBehindAppBar: true,
+      extendBody: true,
       appBar: showButtons.value
           ? AppBar(
               backgroundColor: Colors.black38,
@@ -79,16 +82,30 @@ class MediaView extends HookWidget {
               ],
             )
           : null,
-      extendBodyBehindAppBar: true,
-      body: GestureDetector(
-        onTapUp: (details) => showButtons.value = !showButtons.value,
-        child: PhotoView(
-          minScale: PhotoViewComputedScale.contained,
-          initialScale: PhotoViewComputedScale.contained,
-          imageProvider: CachedNetworkImageProvider(url),
-          heroAttributes: PhotoViewHeroAttributes(tag: url),
-          loadingBuilder: (context, event) =>
-              Center(child: CircularProgressIndicator()),
+      body: Dismissible(
+        direction: DismissDirection.vertical,
+        onDismissed: (_) => Navigator.of(context).pop(),
+        key: const Key('media view'),
+        background: Container(color: Colors.black),
+        dismissThresholds: {
+          DismissDirection.vertical: 0,
+        },
+        confirmDismiss: (direction) => Future.value(isZoomedOut.value),
+        resizeDuration: null,
+        child: GestureDetector(
+          onTapUp: (details) => showButtons.value = !showButtons.value,
+          child: PhotoView(
+            scaleStateChangedCallback: (value) {
+              isZoomedOut.value = value == PhotoViewScaleState.zoomedOut ||
+                  value == PhotoViewScaleState.initial;
+            },
+            minScale: PhotoViewComputedScale.contained,
+            initialScale: PhotoViewComputedScale.contained,
+            imageProvider: CachedNetworkImageProvider(url),
+            heroAttributes: PhotoViewHeroAttributes(tag: url),
+            loadingBuilder: (context, event) =>
+                Center(child: CircularProgressIndicator()),
+          ),
         ),
       ),
     );

--- a/lib/widgets/media_view.dart
+++ b/lib/widgets/media_view.dart
@@ -1,0 +1,50 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:photo_view/photo_view.dart';
+
+class MediaView extends HookWidget {
+  final String url;
+
+  const MediaView(this.url);
+
+  @override
+  Widget build(BuildContext context) {
+    var showButtons = useState(true);
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor:
+            showButtons.value ? Colors.black38 : Colors.transparent,
+        shadowColor: Colors.transparent,
+        leading: showButtons.value ? CloseButton() : Container(),
+        actions: showButtons.value
+            ? [
+                IconButton(
+                  icon: Icon(Icons.share),
+                  tooltip: 'share',
+                  onPressed: () {},
+                ),
+                IconButton(
+                  icon: Icon(Icons.file_download),
+                  tooltip: 'download',
+                  onPressed: () {},
+                ),
+              ]
+            : null,
+      ),
+      extendBodyBehindAppBar: true,
+      body: GestureDetector(
+        onTapUp: (details) => showButtons.value = !showButtons.value,
+        child: PhotoView(
+          minScale: PhotoViewComputedScale.contained,
+          initialScale: PhotoViewComputedScale.contained,
+          imageProvider: CachedNetworkImageProvider(url),
+          heroAttributes: PhotoViewHeroAttributes(tag: url),
+          loadingBuilder: (context, event) =>
+              Center(child: CircularProgressIndicator()),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/media_view.dart
+++ b/lib/widgets/media_view.dart
@@ -1,8 +1,11 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:photo_view/photo_view.dart';
+
+import 'bottom_modal.dart';
 
 class MediaView extends HookWidget {
   final String url;
@@ -27,6 +30,35 @@ class MediaView extends HookWidget {
       SystemChrome.setEnabledSystemUIOverlays([]);
     }
 
+    share() {
+      showModalBottomSheet(
+        backgroundColor: Colors.transparent,
+        context: context,
+        builder: (context) => BottomModal(
+          child: Column(
+            children: [
+              ListTile(
+                leading: Icon(Icons.link),
+                title: Text('Share link'),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  Share.text('Share image url', url, 'text/plain');
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.image),
+                title: Text('Share file'),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  // TODO: share file
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: showButtons.value
           ? AppBar(
@@ -37,7 +69,7 @@ class MediaView extends HookWidget {
                 IconButton(
                   icon: Icon(Icons.share),
                   tooltip: 'share',
-                  onPressed: () {},
+                  onPressed: share,
                 ),
                 IconButton(
                   icon: Icon(Icons.file_download),

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -374,6 +374,7 @@ class Post extends StatelessWidget {
         url: post.url,
         child: CachedNetworkImage(
           imageUrl: post.url,
+          errorWidget: (_, __, ___) => Icon(Icons.warning),
           progressIndicatorBuilder: (context, url, progress) =>
               CircularProgressIndicator(value: progress.progress),
         ),

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -47,8 +47,6 @@ class Post extends StatelessWidget {
 
   // == ACTIONS ==
 
-  void _openLink() => urlLauncher(post.url);
-
   void _savePost() {
     print('SAVE POST');
   }

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -8,6 +8,7 @@ import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart' as ul;
 
 import '../pages/full_post.dart';
+import '../pages/media_view.dart';
 import '../url_launcher.dart';
 import '../util/api_extensions.dart';
 import '../util/goto.dart';
@@ -25,7 +26,13 @@ MediaType whatType(String url) {
   if (url == null) return MediaType.other;
 
   // TODO: make detection more nuanced
-  if (url.endsWith('.jpg') || url.endsWith('.png') || url.endsWith('.gif')) {
+  if (url.endsWith('.jpg') ||
+      url.endsWith('.jpeg') ||
+      url.endsWith('.png') ||
+      url.endsWith('.gif') ||
+      url.endsWith('.webp') ||
+      url.endsWith('.bmp') ||
+      url.endsWith('.wbpm')) {
     return MediaType.image;
   }
   return MediaType.other;
@@ -42,10 +49,10 @@ class Post extends StatelessWidget {
 
   void _openLink() => urlLauncher(post.url);
 
-  void _openFullImage() {
-    // TODO: fullscreen media view
-    print('OPEN FULL IMAGE');
-  }
+  void _openFullImage(BuildContext context) =>
+      Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) => MediaViewPage(post.url),
+      ));
 
   // POST ACTIONS
 
@@ -371,11 +378,14 @@ class Post extends StatelessWidget {
       assert(post.url != null);
 
       return InkWell(
-        onTap: _openFullImage,
-        child: CachedNetworkImage(
-          imageUrl: post.url,
-          progressIndicatorBuilder: (context, url, progress) =>
-              CircularProgressIndicator(value: progress.progress),
+        onTap: () => _openFullImage(context),
+        child: Hero(
+          tag: post.url,
+          child: CachedNetworkImage(
+            imageUrl: post.url,
+            progressIndicatorBuilder: (context, url, progress) =>
+                CircularProgressIndicator(value: progress.progress),
+          ),
         ),
       );
     }

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -13,6 +13,7 @@ import '../url_launcher.dart';
 import '../util/api_extensions.dart';
 import '../util/goto.dart';
 import 'bottom_modal.dart';
+import 'fullscreenable_image.dart';
 import 'markdown_text.dart';
 
 enum MediaType {
@@ -377,15 +378,12 @@ class Post extends StatelessWidget {
     Widget postImage() {
       assert(post.url != null);
 
-      return InkWell(
-        onTap: () => _openFullImage(context),
-        child: Hero(
-          tag: post.url,
-          child: CachedNetworkImage(
-            imageUrl: post.url,
-            progressIndicatorBuilder: (context, url, progress) =>
-                CircularProgressIndicator(value: progress.progress),
-          ),
+      return FullscreenableImage(
+        url: post.url,
+        child: CachedNetworkImage(
+          imageUrl: post.url,
+          progressIndicatorBuilder: (context, url, progress) =>
+              CircularProgressIndicator(value: progress.progress),
         ),
       );
     }

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -8,7 +8,6 @@ import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart' as ul;
 
 import '../pages/full_post.dart';
-import '../pages/media_view.dart';
 import '../url_launcher.dart';
 import '../util/api_extensions.dart';
 import '../util/goto.dart';
@@ -49,11 +48,6 @@ class Post extends StatelessWidget {
   // == ACTIONS ==
 
   void _openLink() => urlLauncher(post.url);
-
-  void _openFullImage(BuildContext context) =>
-      Navigator.of(context).push(MaterialPageRoute(
-        builder: (context) => MediaViewPage(post.url),
-      ));
 
   // POST ACTIONS
 

--- a/lib/widgets/user_profile.dart
+++ b/lib/widgets/user_profile.dart
@@ -96,6 +96,7 @@ class UserProfile extends HookWidget {
           if (userViewSnap.data?.banner != null)
             CachedNetworkImage(
               imageUrl: userViewSnap.data.banner,
+              errorWidget: (_, __, ___) => Container(),
             )
           else
             Container(
@@ -154,6 +155,7 @@ class UserProfile extends HookWidget {
                         borderRadius: BorderRadius.all(Radius.circular(12)),
                         child: CachedNetworkImage(
                           imageUrl: userViewSnap.data.avatar,
+                          errorWidget: (_, __, ___) => Container(),
                         ),
                       ),
                     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -471,6 +471,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.2"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
+  photo_view: ^0.10.2
   url_launcher: ^5.5.1
   markdown: ^2.1.8
   flutter_markdown: ^0.4.3
@@ -51,7 +52,6 @@ dev_dependencies:
   mobx_codegen: ^1.1.0
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
 flutter:
   # The following line ensures that the Material Icons font is


### PR DESCRIPTION
Basic media view, for now supports only images. no galleries, no videos (except gifs)

implemented features:
* hero animation
* pinch to zoom + double tap to zoom
* tap to hide/show controls
* swipe up/down do dismiss
* url share

added widget for easier wrapping of pictures: `FullscreenableImage`

implemented in:
* post
* markdown
* community logo & banner
* instance logo & banner

![1](https://user-images.githubusercontent.com/10037914/92963779-4a1c3380-f473-11ea-8987-4b5aad688f85.gif)
![2](https://user-images.githubusercontent.com/10037914/92963966-98313700-f473-11ea-8d2d-bc5ce962923f.gif)
![3](https://user-images.githubusercontent.com/10037914/92964036-bd25aa00-f473-11ea-8870-ebd1d4cfd588.gif)
![4](https://user-images.githubusercontent.com/10037914/92964051-c151c780-f473-11ea-9953-261bd9a676cb.gif)

