### PR TITLE
Link handling

### DIFF
--- a/lib/pages/communities_list.dart
+++ b/lib/pages/communities_list.dart
@@ -31,7 +31,10 @@ class CommunitiesListPage extends StatelessWidget {
             subtitle: communities[i].description != null
                 ? Opacity(
                     opacity: 0.5,
-                    child: MarkdownText(communities[i].description),
+                    child: MarkdownText(
+                      communities[i].description,
+                      instanceUrl: communities[i].instanceUrl,
+                    ),
                   )
                 : null,
             onTap: () => goToCommunity.byId(

--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -433,7 +433,8 @@ class _AboutTab extends StatelessWidget {
         if (community.description != null) ...[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 15),
-            child: MarkdownText(community.description),
+            child: MarkdownText(community.description,
+                instanceUrl: community.instanceUrl),
           ),
           _Divider(),
         ],

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -208,7 +208,9 @@ class InstancePage extends HookWidget {
                   Center(child: Text('comments go here')),
                 ],
               ),
-              _AboutTab(site, communitiesFuture: communitiesFuture),
+              _AboutTab(site,
+                  communitiesFuture: communitiesFuture,
+                  instanceUrl: instanceUrl),
             ],
           ),
         ),
@@ -241,9 +243,12 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 class _AboutTab extends HookWidget {
   final FullSiteView site;
   final Future<List<CommunityView>> communitiesFuture;
+  final String instanceUrl;
 
-  const _AboutTab(this.site, {@required this.communitiesFuture})
-      : assert(communitiesFuture != null);
+  const _AboutTab(this.site,
+      {@required this.communitiesFuture, @required this.instanceUrl})
+      : assert(communitiesFuture != null),
+        assert(instanceUrl != null);
 
   void goToUser(int id) {
     print('GO TO USER $id');
@@ -280,7 +285,10 @@ class _AboutTab extends HookWidget {
           children: [
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 15),
-              child: MarkdownText(site.site.description),
+              child: MarkdownText(
+                site.site.description,
+                instanceUrl: instanceUrl,
+              ),
             ),
             _Divider(),
             SizedBox(
@@ -356,7 +364,9 @@ class _AboutTab extends HookWidget {
                           e.preferredUsername.isEmpty)
                       ? '@${e.name}'
                       : e.preferredUsername),
-                  subtitle: e.bio != null ? MarkdownText(e.bio) : null,
+                  subtitle: e.bio != null
+                      ? MarkdownText(e.bio, instanceUrl: instanceUrl)
+                      : null,
                   onTap: () => goToUser(e.id),
                   leading: e.avatar != null
                       ? CachedNetworkImage(

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -18,6 +18,15 @@ class UserPage extends HookWidget {
             .getUserDetails(
                 userId: userId, savedOnly: true, sort: SortType.active)
             .then((res) => res.user);
+  UserPage.fromName({@required this.instanceUrl, @required username})
+      : assert(instanceUrl != null),
+        assert(username != null),
+        userId = null,
+        _userView = LemmyApi(instanceUrl)
+            .v1
+            .getUserDetails(
+                username: username, savedOnly: true, sort: SortType.active)
+            .then((res) => res.user);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -18,7 +18,7 @@ class UserPage extends HookWidget {
             .getUserDetails(
                 userId: userId, savedOnly: true, sort: SortType.active)
             .then((res) => res.user);
-  UserPage.fromName({@required this.instanceUrl, @required username})
+  UserPage.fromName({@required this.instanceUrl, @required String username})
       : assert(instanceUrl != null),
         assert(username != null),
         userId = null,

--- a/lib/pages/users_list.dart
+++ b/lib/pages/users_list.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:lemmy_api_client/lemmy_api_client.dart';
 
+import '../util/api_extensions.dart';
 import '../widgets/markdown_text.dart';
 
 class UsersListPage extends StatelessWidget {
@@ -35,7 +36,10 @@ class UsersListPage extends StatelessWidget {
             subtitle: users[i].bio != null
                 ? Opacity(
                     opacity: 0.5,
-                    child: MarkdownText(users[i].bio),
+                    child: MarkdownText(
+                      users[i].bio,
+                      instanceUrl: users[i].instanceUrl,
+                    ),
                   )
                 : null,
             onTap: () => goToUser(context, users[i].id),

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -1,6 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
 
-Future<void> urlLauncher(String url) async {
+import 'stores/accounts_store.dart';
+
+Future<void> urlLauncher(BuildContext c, String url) async {
+  final instances = c.read<AccountsStore>().users.keys.toList();
+  print(instances);
+
+  // CHECK IF LINK TO USER
+
+  // TODO: link to user
+
+  // CHECK IF LINK TO COMMUNITY
+
+  // TODO; link to community
+
+  // CHECK IF REDIRECTS TO A PAGE ON ONE OF ADDED INSTANCES
+
+  final instanceRegex = RegExp(r'^(?:https?:\/\/)?([\w\.-]+)(.+)$');
+  final match = instanceRegex.firstMatch(url);
+
+  final matchedDomain = match.group(1);
+  final rest = match.group(2);
+
+  print('matched domain: $matchedDomain, rest: $rest');
+  print(rest.length);
+
+  if (instances.any((e) => e == match.group(1))) {
+    switch (rest.split('/')[1]) {
+      case 'c':
+        print('comunity');
+        return;
+      case 'u':
+        print('user');
+        return;
+      case 'post':
+        print('post');
+        return;
+      case 'pictrs':
+        print('pictures');
+        return;
+      case 'communities':
+        print('communities');
+        return;
+      case 'modlog':
+        print('modlog');
+        return;
+      case 'inbox':
+        print('inbox');
+        return;
+      case 'create_post':
+      case 'create_community':
+      case 'sponsors':
+      case 'instances':
+      case 'docs':
+        openInBrowser(url);
+        return;
+      default:
+    }
+  }
+
+  // REGULAR LINK STUFF
+
+  openInBrowser(url);
+}
+
+void openInBrowser(String url) async {
   if (await ul.canLaunch(url)) {
     await ul.launch(url);
   } else {

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -8,7 +8,7 @@ import 'pages/instance.dart';
 import 'pages/user.dart';
 import 'stores/accounts_store.dart';
 
-Future<void> urlLauncher({
+Future<void> linkLauncher({
   @required BuildContext context,
   @required String url,
   @required String instanceUrl,

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:lemmur/pages/community.dart';
+import 'package:lemmur/pages/full_post.dart';
+import 'package:lemmur/pages/user.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
 
@@ -21,34 +24,51 @@ Future<void> urlLauncher(BuildContext c, String url) async {
   final instanceRegex = RegExp(r'^(?:https?:\/\/)?([\w\.-]+)(.+)$');
   final match = instanceRegex.firstMatch(url);
 
-  final matchedDomain = match.group(1);
+  final matchedInstance = match.group(1);
   final rest = match.group(2);
 
-  print('matched domain: $matchedDomain, rest: $rest');
+  print('matched domain: $matchedInstance, rest: $rest');
   print(rest.length);
 
   if (instances.any((e) => e == match.group(1))) {
-    switch (rest.split('/')[1]) {
+    push(Widget Function(BuildContext) builder) {
+      Navigator.of(c).push(MaterialPageRoute(builder: builder));
+    }
+
+    final split = rest.split('/');
+    switch (split[1]) {
       case 'c':
-        print('comunity');
-        return;
+        return push((_) => CommunityPage.fromName(
+            communityName: split[2], instanceUrl: matchedInstance));
+
       case 'u':
-        print('user');
-        return;
+        return push((_) => UserPage.fromName(
+            instanceUrl: matchedInstance, username: split[2]));
+
       case 'post':
-        print('post');
-        return;
+        return push((_) => FullPostPage(
+            id: int.parse(split[2]), instanceUrl: matchedInstance));
+
       case 'pictrs':
-        print('pictures');
+        // TODO: put here push to media view
         return;
+
       case 'communities':
-        print('communities');
+        // TODO: put here push to communities page
         return;
+
       case 'modlog':
+        // TODO: put here push to modlog
         print('modlog');
         return;
       case 'inbox':
+        // TODO: put here push to inbox
         print('inbox');
+        return;
+      case 'search':
+        // TODO: *maybe* put here push to search. we'll see
+        //        how much web version differs form the app
+        print('search');
         return;
       case 'create_post':
       case 'create_community':

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -40,9 +40,6 @@ Future<void> urlLauncher({
   final matchedInstance = match.group(1);
   final rest = match.group(2);
 
-  print('matched domain: $matchedInstance, rest: $rest');
-  print(rest.length);
-
   if (instances.any((e) => e == match.group(1))) {
     final split = rest.split('/');
     switch (split[1]) {

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -4,6 +4,7 @@ import 'package:url_launcher/url_launcher.dart' as ul;
 
 import 'pages/community.dart';
 import 'pages/full_post.dart';
+import 'pages/instance.dart';
 import 'pages/user.dart';
 import 'stores/accounts_store.dart';
 
@@ -34,13 +35,16 @@ Future<void> urlLauncher({
 
   // CHECK IF REDIRECTS TO A PAGE ON ONE OF ADDED INSTANCES
 
-  final instanceRegex = RegExp(r'^(?:https?:\/\/)?([\w\.-]+)(.+)$');
+  final instanceRegex = RegExp(r'^(?:https?:\/\/)?([\w\.-]+)(.*)$');
   final match = instanceRegex.firstMatch(url);
 
-  final matchedInstance = match.group(1);
-  final rest = match.group(2);
+  final matchedInstance = match?.group(1);
+  final rest = match?.group(2);
 
-  if (instances.any((e) => e == match.group(1))) {
+  if (matchedInstance != null && instances.any((e) => e == match.group(1))) {
+    if (rest.isEmpty || rest == '/') {
+      return push((_) => InstancePage(instanceUrl: matchedInstance));
+    }
     final split = rest.split('/');
     switch (split[1]) {
       case 'c':
@@ -90,9 +94,9 @@ Future<void> urlLauncher({
       case 'sponsors':
       case 'instances':
       case 'docs':
-        openInBrowser(url);
-        return;
+        break;
       default:
+        break;
     }
   }
 

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -102,12 +102,12 @@ Future<void> linkLauncher({
 
   // FALLBACK TO REGULAR LINK STUFF
 
-  openInBrowser(url);
+  return openInBrowser(url);
 }
 
-void openInBrowser(String url) async {
+Future<void> openInBrowser(String url) async {
   if (await ul.canLaunch(url)) {
-    await ul.launch(url);
+    return await ul.launch(url);
   } else {
     throw Exception();
     // TODO: handle opening links to stuff in app

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -13,8 +13,8 @@ Future<void> urlLauncher({
   @required String url,
   @required String instanceUrl,
 }) async {
-  push(Widget Function(BuildContext) builder) {
-    Navigator.of(context).push(MaterialPageRoute(builder: builder));
+  push(Widget Function() builder) {
+    Navigator.of(context).push(MaterialPageRoute(builder: (c) => builder()));
   }
 
   final instances = context.read<AccountsStore>().users.keys.toList();
@@ -23,13 +23,13 @@ Future<void> urlLauncher({
 
   // CHECK IF LINK TO USER
   if (chonks[1] == 'u') {
-    return push((_) =>
-        UserPage.fromName(instanceUrl: instanceUrl, username: chonks[2]));
+    return push(
+        () => UserPage.fromName(instanceUrl: instanceUrl, username: chonks[2]));
   }
 
   // CHECK IF LINK TO COMMUNITY
   if (chonks[1] == 'c') {
-    return push((_) => CommunityPage.fromName(
+    return push(() => CommunityPage.fromName(
         communityName: chonks[2], instanceUrl: instanceUrl));
   }
 
@@ -43,21 +43,21 @@ Future<void> urlLauncher({
 
   if (matchedInstance != null && instances.any((e) => e == match.group(1))) {
     if (rest.isEmpty || rest == '/') {
-      return push((_) => InstancePage(instanceUrl: matchedInstance));
+      return push(() => InstancePage(instanceUrl: matchedInstance));
     }
     final split = rest.split('/');
     switch (split[1]) {
       case 'c':
-        return push((_) => CommunityPage.fromName(
+        return push(() => CommunityPage.fromName(
             communityName: split[2], instanceUrl: matchedInstance));
 
       case 'u':
-        return push((_) => UserPage.fromName(
+        return push(() => UserPage.fromName(
             instanceUrl: matchedInstance, username: split[2]));
 
       case 'post':
         if (split.length == 3) {
-          return push((_) => FullPostPage(
+          return push(() => FullPostPage(
               id: int.parse(split[2]), instanceUrl: matchedInstance));
         } else if (split.length == 5) {
           // TODO: post with focus on comment thread

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -55,8 +55,14 @@ Future<void> urlLauncher({
             instanceUrl: matchedInstance, username: split[2]));
 
       case 'post':
-        return push((_) => FullPostPage(
-            id: int.parse(split[2]), instanceUrl: matchedInstance));
+        if (split.length == 3) {
+          return push((_) => FullPostPage(
+              id: int.parse(split[2]), instanceUrl: matchedInstance));
+        } else if (split.length == 5) {
+          return;
+          // TODO: post with focus on comment thread
+        }
+        break;
 
       case 'pictrs':
         // TODO: put here push to media view

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -56,17 +56,20 @@ Future<void> urlLauncher({
           return push((_) => FullPostPage(
               id: int.parse(split[2]), instanceUrl: matchedInstance));
         } else if (split.length == 5) {
-          return;
           // TODO: post with focus on comment thread
+          print('comment in post');
+          return;
         }
         break;
 
       case 'pictrs':
         // TODO: put here push to media view
+        print('pictrs');
         return;
 
       case 'communities':
         // TODO: put here push to communities page
+        print('communities');
         return;
 
       case 'modlog':

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -1,23 +1,36 @@
 import 'package:flutter/material.dart';
-import 'package:lemmur/pages/community.dart';
-import 'package:lemmur/pages/full_post.dart';
-import 'package:lemmur/pages/user.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
 
+import 'pages/community.dart';
+import 'pages/full_post.dart';
+import 'pages/user.dart';
 import 'stores/accounts_store.dart';
 
-Future<void> urlLauncher(BuildContext c, String url) async {
-  final instances = c.read<AccountsStore>().users.keys.toList();
-  print(instances);
+Future<void> urlLauncher({
+  @required BuildContext context,
+  @required String url,
+  @required String instanceUrl,
+}) async {
+  push(Widget Function(BuildContext) builder) {
+    Navigator.of(context).push(MaterialPageRoute(builder: builder));
+  }
+
+  final instances = context.read<AccountsStore>().users.keys.toList();
+
+  final chonks = url.split('/');
 
   // CHECK IF LINK TO USER
-
-  // TODO: link to user
+  if (chonks[1] == 'u') {
+    return push((_) =>
+        UserPage.fromName(instanceUrl: instanceUrl, username: chonks[2]));
+  }
 
   // CHECK IF LINK TO COMMUNITY
-
-  // TODO; link to community
+  if (chonks[1] == 'c') {
+    return push((_) => CommunityPage.fromName(
+        communityName: chonks[2], instanceUrl: instanceUrl));
+  }
 
   // CHECK IF REDIRECTS TO A PAGE ON ONE OF ADDED INSTANCES
 
@@ -31,10 +44,6 @@ Future<void> urlLauncher(BuildContext c, String url) async {
   print(rest.length);
 
   if (instances.any((e) => e == match.group(1))) {
-    push(Widget Function(BuildContext) builder) {
-      Navigator.of(c).push(MaterialPageRoute(builder: builder));
-    }
-
     final split = rest.split('/');
     switch (split[1]) {
       case 'c':
@@ -81,7 +90,7 @@ Future<void> urlLauncher(BuildContext c, String url) async {
     }
   }
 
-  // REGULAR LINK STUFF
+  // FALLBACK TO REGULAR LINK STUFF
 
   openInBrowser(url);
 }

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -169,7 +169,9 @@ class Comment extends StatelessWidget {
           style: TextStyle(fontStyle: FontStyle.italic),
         ));
       } else {
-        return Flexible(child: MarkdownText(commentTree.comment.content));
+        return Flexible(
+            child: MarkdownText(commentTree.comment.content,
+                instanceUrl: commentTree.comment.instanceUrl));
       }
     }();
 

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -6,20 +6,22 @@ import 'package:markdown/markdown.dart' as md;
 import '../url_launcher.dart';
 
 class MarkdownText extends StatelessWidget {
+  final String instanceUrl;
   final String text;
-  MarkdownText(this.text);
+  MarkdownText(this.text, {@required this.instanceUrl})
+      : assert(instanceUrl != null);
 
   @override
   Widget build(BuildContext context) => MarkdownBody(
         data: text,
         extensionSet: md.ExtensionSet.gitHubWeb,
         onTapLink: (href) {
-          urlLauncher(context, href)
+          urlLauncher(context: context, url: href, instanceUrl: instanceUrl)
               .catchError((e) => Scaffold.of(context).showSnackBar(SnackBar(
                     content: Row(
                       children: [
                         Icon(Icons.warning),
-                        Text("couldn't open link"),
+                        Text("couldn't open link, ${e.toString()}"),
                       ],
                     ),
                   )));

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -14,7 +14,7 @@ class MarkdownText extends StatelessWidget {
         data: text,
         extensionSet: md.ExtensionSet.gitHubWeb,
         onTapLink: (href) {
-          urlLauncher(href)
+          urlLauncher(context, href)
               .catchError((e) => Scaffold.of(context).showSnackBar(SnackBar(
                     content: Row(
                       children: [

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -16,7 +16,7 @@ class MarkdownText extends StatelessWidget {
         data: text,
         extensionSet: md.ExtensionSet.gitHubWeb,
         onTapLink: (href) {
-          urlLauncher(context: context, url: href, instanceUrl: instanceUrl)
+          linkLauncher(context: context, url: href, instanceUrl: instanceUrl)
               .catchError((e) => Scaffold.of(context).showSnackBar(SnackBar(
                     content: Row(
                       children: [

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -145,7 +145,7 @@ class Post extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     void _openLink() =>
-        urlLauncher(context: context, url: post.url, instanceUrl: instanceUrl);
+        linkLauncher(context: context, url: post.url, instanceUrl: instanceUrl);
 
     final urlDomain = () {
       if (post.url == null) return null;

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -144,7 +144,8 @@ class Post extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    void _openLink() => urlLauncher(context, post.url);
+    void _openLink() =>
+        urlLauncher(context: context, url: post.url, instanceUrl: instanceUrl);
 
     final urlDomain = () {
       if (post.url == null) return null;
@@ -437,7 +438,7 @@ class Post extends StatelessWidget {
             if (post.body != null)
               Padding(
                   padding: const EdgeInsets.all(10),
-                  child: MarkdownText(post.body)),
+                  child: MarkdownText(post.body, instanceUrl: instanceUrl)),
             actions(),
           ],
         ),

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -40,8 +40,6 @@ class Post extends StatelessWidget {
 
   // == ACTIONS ==
 
-  void _openLink() => urlLauncher(post.url);
-
   void _openFullImage() {
     // TODO: fullscreen media view
     print('OPEN FULL IMAGE');
@@ -146,6 +144,7 @@ class Post extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    void _openLink() => urlLauncher(context, post.url);
 
     final urlDomain = () {
       if (post.url == null) return null;


### PR DESCRIPTION
link handling for:
- `/u/user`
- `/c/community`
- `https://lemmy.instance/c/community`
- `https://lemmy.instance/u/username`
- `https://lemmy.instance/post/1234`
- `https://lemmy.instance`

widgets not yet implemented, but links are handled for:
- `https://lemmy.instance/post/1234/comment/4321`
- `https://lemmy.instance/pictrs/image/NTxTxwtxcl.jpg`
- `https://lemmy.instance/communities`
- `https://lemmy.instance/modlog`
- `https://lemmy.instance/inbox`
- `https://lemmy.instance/search` (not sure if even should be handled)

everything else (`create_post`, `create_community`, `sponsors`, `instances`, `docs`)
falls back to opening in browser

![Screen Recording 2020-09-12 at 10 25 56](https://user-images.githubusercontent.com/10037914/92991237-c863ee80-f4e2-11ea-91cf-5b7614989e69.gif)
