### PR TITLE
add pull to refresh to infinite scroll

### DIFF
--- a/lib/hooks/refreshable.dart
+++ b/lib/hooks/refreshable.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'memo_future.dart';
+
+class Refreshable<T> {
+  const Refreshable({@required this.snapshot, @required this.refresh})
+      : assert(snapshot != null),
+        assert(refresh != null);
+
+  final AsyncSnapshot<T> snapshot;
+  final AsyncCallback refresh;
+}
+
+/// Similar to [useMemoFuture] but adds a `.refresh` method which
+/// allows to re-run the fetcher. Calling `.refresh` will not
+/// turn AsyncSnapshot into a loading state. Instead it will
+/// replace the ready state with the new data when available
+///
+/// `keys` will re-run the initial fetching thus yielding a
+/// loading state in the AsyncSnapshot
+Refreshable<T> useRefreshable<T>(AsyncValueGetter<T> fetcher,
+    [List<Object> keys = const <dynamic>[]]) {
+  final newData = useState<T>(null);
+  final snapshot = useMemoFuture(() async {
+    newData.value = null;
+    return fetcher();
+  }, keys);
+
+  final outSnapshot = () {
+    if (newData.value != null) {
+      return AsyncSnapshot.withData(ConnectionState.done, newData.value);
+    }
+    return snapshot;
+  }();
+
+  return Refreshable(
+    snapshot: outSnapshot,
+    refresh: () async {
+      newData.value = await fetcher();
+    },
+  );
+}

--- a/lib/pages/communities_tab.dart
+++ b/lib/pages/communities_tab.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fuzzy/fuzzy.dart';
 import 'package:lemmy_api_client/lemmy_api_client.dart';
@@ -94,6 +95,7 @@ class CommunitiesTab extends HookWidget {
     }
 
     refresh() async {
+      await HapticFeedback.mediumImpact();
       try {
         final i = getInstances();
         final c = getCommunities();

--- a/lib/pages/full_post.dart
+++ b/lib/pages/full_post.dart
@@ -60,9 +60,10 @@ class FullPostPage extends HookWidget {
 
     // VARIABLES
 
-    final post = fullPostSnap.hasData ? fullPostSnap.data.post : this.post;
+    final post = updatedPost.value?.post ??
+        (fullPostSnap.hasData ? fullPostSnap.data.post : this.post);
 
-    final fullPost = fullPostSnap.data;
+    final fullPost = updatedPost.value ?? fullPostSnap.data;
 
     // FUNCTIONS
 

--- a/lib/widgets/infinite_scroll.dart
+++ b/lib/widgets/infinite_scroll.dart
@@ -28,10 +28,8 @@ class InfiniteScroll<T> extends HookWidget {
   final InfiniteScrollController controller;
   final Widget prepend;
   final EdgeInsetsGeometry padding;
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
 
-  InfiniteScroll({
+  const InfiniteScroll({
     this.batchSize = 10,
     this.prepend = const SizedBox.shrink(),
     this.padding,
@@ -65,7 +63,6 @@ class InfiniteScroll<T> extends HookWidget {
     final page = data.value.length ~/ batchSize + 1;
 
     return RefreshIndicator(
-      key: _refreshIndicatorKey,
       onRefresh: () async {
         controller.clear();
         await HapticFeedback.mediumImpact();


### PR DESCRIPTION
adds pull to refresh to 90% of pages

in particular:
* every list that uses infinite scroll
* full post
* communities tab

those that are not implemented are mostly *"about"* sections  


also every refresh has medium impact vibration when initiated


https://user-images.githubusercontent.com/10037914/104080009-fd304a00-5225-11eb-99b0-8d5b104d8e61.mov

