### PR TITLE
Allow user to go from comment to post

### DIFF
--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -25,6 +25,7 @@ class Comment extends HookWidget {
   final int indent;
   final int postCreatorId;
   final CommentTree commentTree;
+  final bool detatched;
 
   final bool wasVoted;
 
@@ -40,6 +41,7 @@ class Comment extends HookWidget {
     this.commentTree, {
     this.indent = 0,
     @required this.postCreatorId,
+    this.detatched = false,
   }) : wasVoted =
             (commentTree.comment.myVote ?? VoteType.none) != VoteType.none;
 
@@ -279,6 +281,14 @@ class Comment extends HookWidget {
                                 content: Text('comment copied to clipboard'))));
                   }),
             const Spacer(),
+            if (detatched)
+              _CommentAction(
+                icon: Icons.link,
+                // onPressed: () {},
+                onPressed: () =>
+                    goToPost(context, comment.instanceHost, comment.postId),
+                tooltip: 'go to post',
+              ),
             _CommentAction(
               icon: Icons.more_horiz,
               onPressed: () => _openMoreMenu(context),

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -47,7 +47,25 @@ class Comment extends HookWidget {
     final com = commentTree.comment;
     showInfoTablePopup(context, {
       'id': com.id,
+      'creatorId': com.creatorId,
+      'postId': com.postId,
+      'postName': com.postName,
+      'parentId': com.parentId,
+      'removed': com.removed,
+      'read': com.read,
+      'published': com.published,
+      'updated': com.updated,
+      'deleted': com.deleted,
       'apId': com.apId,
+      'local': com.local,
+      'communityId': com.communityId,
+      'communityActorId': com.communityActorId,
+      'communityLocal': com.communityLocal,
+      'communityName': com.communityName,
+      'communityIcon': com.communityIcon,
+      'banned': com.banned,
+      'bannedFromCommunity': com.bannedFromCommunity,
+      'creatorActirId': com.creatorActorId,
       'userId': com.userId,
       'upvotes': com.upvotes,
       'downvotes': com.downvotes,
@@ -55,8 +73,6 @@ class Comment extends HookWidget {
       '% of upvotes': '${100 * (com.upvotes / (com.upvotes + com.downvotes))}%',
       'hotRank': com.hotRank,
       'hotRankActive': com.hotRankActive,
-      'published': com.published,
-      'updated': com.updated,
     });
   }
 

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -25,7 +25,7 @@ class Comment extends HookWidget {
   final int indent;
   final int postCreatorId;
   final CommentTree commentTree;
-  final bool detatched;
+  final bool detached;
 
   final bool wasVoted;
 
@@ -41,7 +41,7 @@ class Comment extends HookWidget {
     this.commentTree, {
     this.indent = 0,
     @required this.postCreatorId,
-    this.detatched = false,
+    this.detached = false,
   }) : wasVoted =
             (commentTree.comment.myVote ?? VoteType.none) != VoteType.none;
 
@@ -281,10 +281,9 @@ class Comment extends HookWidget {
                                 content: Text('comment copied to clipboard'))));
                   }),
             const Spacer(),
-            if (detatched)
+            if (detached)
               _CommentAction(
                 icon: Icons.link,
-                // onPressed: () {},
                 onPressed: () =>
                     goToPost(context, comment.instanceHost, comment.postId),
                 tooltip: 'go to post',

--- a/lib/widgets/sortable_infinite_list.dart
+++ b/lib/widgets/sortable_infinite_list.dart
@@ -75,7 +75,7 @@ class InfiniteCommentList extends StatelessWidget {
         builder: (comment) => Comment(
           CommentTree(comment),
           postCreatorId: null,
-          detatched: true,
+          detached: true,
         ),
         fetcher: fetcher,
       );

--- a/lib/widgets/sortable_infinite_list.dart
+++ b/lib/widgets/sortable_infinite_list.dart
@@ -75,6 +75,7 @@ class InfiniteCommentList extends StatelessWidget {
         builder: (comment) => Comment(
           CommentTree(comment),
           postCreatorId: null,
+          detatched: true,
         ),
         fetcher: fetcher,
       );


### PR DESCRIPTION
in places like:
* community page
* instance page
* user profile

there are lists with comments but without posts. this PR adds buttons to every each of these comments so that user can easily view the full context :)

BUT it doesn't yet scroll to the desired comment, it only goes to post, so this is something that should be worked on in the future


https://user-images.githubusercontent.com/10037914/104814443-2bf28580-580f-11eb-8ed5-1adc5b3d2ca6.mov

