### PR TITLE
Fix/link launching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added page with saved posts/comments. It can be accessed from the profile tab under the bookmark icon
 
+### Fixed
+
+- Fixed a bug where links would not work on Android 11
+
 ## v0.2.3 - 2021-02-09
 
 Lemmur is now available on the [play store](https://play.google.com/store/apps/details?id=com.krawieck.lemmur) and [f-droid](https://f-droid.org/packages/com.krawieck.lemmur)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Needed for url_launcher to work on android 11 -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="lemmur"


### PR DESCRIPTION
Added a missing link launching permission introduced in API 30

closes #138 