### PR TITLE
Fix time shift bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added page with saved posts/comments. It can be accessed from the profile tab under the bookmark icon
 
+### Fixed
+
+- Time of posts is now displayed properly. Unless you live in UTC zone, then you won't notice a difference.
+
 ## v0.2.3 - 2021-02-09
 
 Lemmur is now available on the [play store](https://play.google.com/store/apps/details?id=com.krawieck.lemmur) and [f-droid](https://f-droid.org/packages/com.krawieck.lemmur)

--- a/lib/util/extensions/datetime.dart
+++ b/lib/util/extensions/datetime.dart
@@ -1,0 +1,12 @@
+import 'package:timeago/timeago.dart' as timeago;
+
+extension FancyTime on DateTime {
+  /// returns [this] time as a relative, human-readable string. In short format
+  String get fancyShort => timeago.format(this,
+      locale: 'en_short',
+      clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
+
+  /// returns [this] time as a relative, human-readable string
+  String get fancy => timeago.format(this,
+      clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
+}

--- a/lib/util/extensions/datetime.dart
+++ b/lib/util/extensions/datetime.dart
@@ -1,12 +1,12 @@
 import 'package:timeago/timeago.dart' as timeago;
 
 extension FancyTime on DateTime {
-  /// returns [this] time as a relative, human-readable string. In short format
+  /// returns `this` time as a relative, human-readable string. In short format
   String get fancyShort => timeago.format(this,
       locale: 'en_short',
       clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
 
-  /// returns [this] time as a relative, human-readable string
+  /// returns `this` time as a relative, human-readable string
   String get fancy => timeago.format(this,
       clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
 }

--- a/lib/util/extensions/datetime.dart
+++ b/lib/util/extensions/datetime.dart
@@ -2,11 +2,8 @@ import 'package:timeago/timeago.dart' as timeago;
 
 extension FancyTime on DateTime {
   /// returns `this` time as a relative, human-readable string. In short format
-  String get fancyShort => timeago.format(this,
-      locale: 'en_short',
-      clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
+  String get fancyShort => timeago.format(this, locale: 'en_short');
 
   /// returns `this` time as a relative, human-readable string
-  String get fancy => timeago.format(this,
-      clock: DateTime.now().subtract(DateTime.now().timeZoneOffset));
+  String get fancy => timeago.format(this);
 }

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v2.dart';
-import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart' as ul;
 
 import '../comment_tree.dart';
@@ -13,6 +12,7 @@ import '../hooks/delayed_loading.dart';
 import '../hooks/logged_in_action.dart';
 import '../hooks/stores.dart';
 import '../util/extensions/api.dart';
+import '../util/extensions/datetime.dart';
 import '../util/goto.dart';
 import '../util/intl.dart';
 import '../util/text_color.dart';
@@ -385,7 +385,7 @@ class CommentWidget extends HookWidget {
                           Text(compactNumber(comment.counts.score +
                               (wasVoted ? 0 : myVote.value.value))),
                         const Text(' · '),
-                        Text(timeago.format(comment.comment.published)),
+                        Text(comment.comment.published.fancy),
                       ],
                     ),
                   )

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v2.dart';
-import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart' as ul;
 
 import '../hooks/delayed_loading.dart';
@@ -15,6 +14,7 @@ import '../pages/full_post.dart';
 import '../url_launcher.dart';
 import '../util/cleanup_url.dart';
 import '../util/extensions/api.dart';
+import '../util/extensions/datetime.dart';
 import '../util/goto.dart';
 import '../util/more_icon.dart';
 import 'bottom_modal.dart';
@@ -216,7 +216,7 @@ class PostWidget extends HookWidget {
                                 ),
                                 TextSpan(
                                     text:
-                                        ' · ${timeago.format(post.post.published, locale: 'en_short')}'),
+                                        ' · ${post.post.published.fancyShort}'),
                                 if (post.post.locked)
                                   const TextSpan(text: ' · 🔒'),
                                 if (post.post.stickied)

--- a/lib/widgets/user_profile.dart
+++ b/lib/widgets/user_profile.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v2.dart';
-import 'package:timeago/timeago.dart' as timeago;
 
 import '../hooks/memo_future.dart';
 import '../hooks/stores.dart';
 import '../pages/manage_account.dart';
 import '../util/extensions/api.dart';
+import '../util/extensions/datetime.dart';
 import '../util/goto.dart';
 import '../util/intl.dart';
 import '../util/text_color.dart';
@@ -282,7 +282,7 @@ class _UserOverview extends HookWidget {
               ),
               const SizedBox(height: 15),
               Text(
-                'Joined ${timeago.format(userView.user.published)}',
+                'Joined ${userView.user.published.fancy}',
                 style: theme.textTheme.bodyText1,
               ),
               Row(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,7 +267,7 @@ packages:
       name: lemmy_api_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.2"
+    version: "0.11.0"
   markdown:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,8 @@ dependencies:
   # utils
   timeago: ^2.0.27
   fuzzy: <1.0.0
-  lemmy_api_client: ^0.10.2
+  lemmy_api_client: ^0.11.0
+
   matrix4_transform: ^1.1.7
 
   flutter:


### PR DESCRIPTION
fixes #150 

the bug was that time from server is in UTC format, and our time is in local format, so it needed to be shifted back to UTC.

oddly enough `.toUtc()` method didn't work

also added a `DateTime` extension for easier use