### PR TITLE
fix markdown quote blocks & make code blocks have monospace font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- Quote blocks in posts and comments are now much prettier
+- Code blocks nwo have monospace font. As they should
+
 ## v0.3.0 - 2021-02-25
 
 WARNING: due to some internal changes your local settings will be reset (logged out of accounts, removed instances, theme back to default)

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -31,7 +31,7 @@ class MarkdownText extends StatelessWidget {
           border: Border(left: BorderSide(width: 2, color: theme.accentColor)),
         ),
         code: theme.textTheme.bodyText1
-            // use a font from google fonts maybe? the defaults aren't very pretty
+            // TODO: use a font from google fonts maybe? the defaults aren't very pretty
             .copyWith(fontFamily: Platform.isIOS ? 'Courier' : 'monospace'),
       ),
       onTapLink: (href) {

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -28,6 +30,9 @@ class MarkdownText extends StatelessWidget {
           color: Colors.grey.withOpacity(0.3),
           border: Border(left: BorderSide(width: 2, color: theme.accentColor)),
         ),
+        code: theme.textTheme.bodyText1
+            // use a font from google fonts maybe? the defaults aren't very pretty
+            .copyWith(fontFamily: Platform.isIOS ? 'Courier' : 'monospace'),
       ),
       onTapLink: (href) {
         linkLauncher(context: context, url: href, instanceHost: instanceHost)

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -17,32 +17,41 @@ class MarkdownText extends StatelessWidget {
       : assert(instanceHost != null);
 
   @override
-  Widget build(BuildContext context) => MarkdownBody(
-        selectable: selectable,
-        data: text,
-        extensionSet: md.ExtensionSet.gitHubWeb,
-        onTapLink: (href) {
-          linkLauncher(context: context, url: href, instanceHost: instanceHost)
-              .catchError((e) => Scaffold.of(context).showSnackBar(SnackBar(
-                    content: Row(
-                      children: [
-                        const Icon(Icons.warning),
-                        Text("couldn't open link, ${e.toString()}"),
-                      ],
-                    ),
-                  )));
-        },
-        imageBuilder: (uri, title, alt) => FullscreenableImage(
-          url: uri.toString(),
-          child: CachedNetworkImage(
-            imageUrl: uri.toString(),
-            errorWidget: (context, url, error) => Row(
-              children: [
-                const Icon(Icons.warning),
-                Text("couldn't load image, ${error.toString()}")
-              ],
-            ),
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MarkdownBody(
+      selectable: selectable,
+      data: text,
+      extensionSet: md.ExtensionSet.gitHubWeb,
+      styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
+        blockquoteDecoration: BoxDecoration(
+          color: Colors.grey.withOpacity(0.3),
+          border: Border(left: BorderSide(width: 2, color: theme.accentColor)),
+        ),
+      ),
+      onTapLink: (href) {
+        linkLauncher(context: context, url: href, instanceHost: instanceHost)
+            .catchError((e) => Scaffold.of(context).showSnackBar(SnackBar(
+                  content: Row(
+                    children: [
+                      const Icon(Icons.warning),
+                      Text("couldn't open link, ${e.toString()}"),
+                    ],
+                  ),
+                )));
+      },
+      imageBuilder: (uri, title, alt) => FullscreenableImage(
+        url: uri.toString(),
+        child: CachedNetworkImage(
+          imageUrl: uri.toString(),
+          errorWidget: (context, url, error) => Row(
+            children: [
+              const Icon(Icons.warning),
+              Text("couldn't load image, ${error.toString()}")
+            ],
           ),
         ),
-      );
+      ),
+    );
+  }
 }


### PR DESCRIPTION
* fix markdown quote blocks, also added a cute line on the left (#155)
* code blocks now have monospace font. as they should.

![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 11 41 03](https://user-images.githubusercontent.com/10037914/110136774-5f459f80-7dd0-11eb-80f3-618ac8a4a8e2.png)
![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 11 40 45](https://user-images.githubusercontent.com/10037914/110136779-610f6300-7dd0-11eb-982d-1b81df1cb412.png)
![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 11 41 23](https://user-images.githubusercontent.com/10037914/110136783-61a7f980-7dd0-11eb-81dc-6c6d91f142ba.png)
![Simulator Screen Shot - iPhone 11 - 2021-03-05 at 11 56 38](https://user-images.githubusercontent.com/10037914/110136784-62409000-7dd0-11eb-9816-b840b09543ae.png)
