### PR TITLE
Migrate esys_flutter_share to share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Share buttons on windows/linux now copy the data to the clipboard
+
 ### Fixed
 
 - Quote blocks in posts and comments are now much prettier

--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -16,6 +15,7 @@ import '../util/extensions/spaced.dart';
 import '../util/goto.dart';
 import '../util/intl.dart';
 import '../util/more_icon.dart';
+import '../util/share.dart';
 import '../widgets/avatar.dart';
 import '../widgets/bottom_modal.dart';
 import '../widgets/fullscreenable_image.dart';
@@ -108,8 +108,7 @@ class CommunityPage extends HookWidget {
     }
 
     // FUNCTIONS
-    void _share() =>
-        Share.text('Share instance', community.community.actorId, 'text/plain');
+    void _share() => Share.share(community.community.actorId, context: context);
 
     void _openMoreMenu() {
       showBottomModal(

--- a/lib/pages/community.dart
+++ b/lib/pages/community.dart
@@ -108,7 +108,7 @@ class CommunityPage extends HookWidget {
     }
 
     // FUNCTIONS
-    void _share() => Share.share(community.community.actorId, context: context);
+    void _share() => share(community.community.actorId, context: context);
 
     void _openMoreMenu() {
       showBottomModal(

--- a/lib/pages/full_post.dart
+++ b/lib/pages/full_post.dart
@@ -84,7 +84,7 @@ class FullPostPage extends HookWidget {
       }
     }
 
-    sharePost() => Share.share(post.post.apId, context: context);
+    sharePost() => share(post.post.apId, context: context);
 
     comment() async {
       final newComment = await showCupertinoModalPopup<CommentView>(

--- a/lib/pages/full_post.dart
+++ b/lib/pages/full_post.dart
@@ -1,4 +1,3 @@
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,6 +9,7 @@ import '../hooks/refreshable.dart';
 import '../hooks/stores.dart';
 import '../util/extensions/api.dart';
 import '../util/more_icon.dart';
+import '../util/share.dart';
 import '../widgets/comment_section.dart';
 import '../widgets/post.dart';
 import '../widgets/reveal_after_scroll.dart';
@@ -84,7 +84,7 @@ class FullPostPage extends HookWidget {
       }
     }
 
-    sharePost() => Share.text('Share post', post.post.apId, 'text/plain');
+    sharePost() => Share.share(post.post.apId, context: context);
 
     comment() async {
       final newComment = await showCupertinoModalPopup<CommentView>(

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -12,6 +11,7 @@ import '../util/extensions/api.dart';
 import '../util/extensions/spaced.dart';
 import '../util/goto.dart';
 import '../util/more_icon.dart';
+import '../util/share.dart';
 import '../util/text_color.dart';
 import '../widgets/avatar.dart';
 import '../widgets/bottom_modal.dart';
@@ -29,9 +29,6 @@ class InstancePage extends HookWidget {
   final String instanceHost;
   final Future<FullSiteView> siteFuture;
   final Future<List<CommunityView>> communitiesFuture;
-
-  void _share() =>
-      Share.text('Share instance', 'https://$instanceHost', 'text/plain');
 
   InstancePage({@required this.instanceHost})
       : assert(instanceHost != null),
@@ -69,6 +66,8 @@ class InstancePage extends HookWidget {
     }
 
     final site = siteSnap.data;
+
+    void _share() => Share.share('https://$instanceHost', context: context);
 
     void _openMoreMenu(BuildContext c) {
       showBottomModal(

--- a/lib/pages/instance.dart
+++ b/lib/pages/instance.dart
@@ -67,7 +67,7 @@ class InstancePage extends HookWidget {
 
     final site = siteSnap.data;
 
-    void _share() => Share.share('https://$instanceHost', context: context);
+    void _share() => share('https://$instanceHost', context: context);
 
     void _openMoreMenu(BuildContext c) {
       showBottomModal(

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -35,7 +35,7 @@ class MediaViewPage extends HookWidget {
 
     // TODO: hide navbar and topbar on android without a content jump
 
-    share() {
+    sharePhoto() {
       showBottomModal(
         context: context,
         builder: (context) => Column(
@@ -45,7 +45,7 @@ class MediaViewPage extends HookWidget {
               title: const Text('Share link'),
               onTap: () {
                 Navigator.of(context).pop();
-                Share.share(url, context: context);
+                share(url, context: context);
               },
             ),
             ListTile(
@@ -77,7 +77,7 @@ class MediaViewPage extends HookWidget {
                 IconButton(
                   icon: const Icon(Icons.share),
                   tooltip: 'share',
-                  onPressed: share,
+                  onPressed: sharePhoto,
                 ),
                 IconButton(
                   icon: const Icon(Icons.file_download),

--- a/lib/pages/media_view.dart
+++ b/lib/pages/media_view.dart
@@ -1,12 +1,12 @@
 import 'dart:math' show max, min;
 
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:matrix4_transform/matrix4_transform.dart';
 import 'package:photo_view/photo_view.dart';
 
+import '../util/share.dart';
 import '../widgets/bottom_modal.dart';
 
 /// View to interact with a media object. Zoom in/out, download, share, etc.
@@ -45,7 +45,7 @@ class MediaViewPage extends HookWidget {
               title: const Text('Share link'),
               onTap: () {
                 Navigator.of(context).pop();
-                Share.text('Share image url', url, 'text/plain');
+                Share.share(url, context: context);
               },
             ),
             ListTile(

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -1,10 +1,10 @@
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v2.dart';
 
 import '../hooks/logged_in_action.dart';
+import '../util/share.dart';
 import '../widgets/user_profile.dart';
 import 'write_message.dart';
 
@@ -49,8 +49,10 @@ class UserPage extends HookWidget {
             SendMessageButton(userDetailsSnap.data.userView.user),
             IconButton(
               icon: const Icon(Icons.share),
-              onPressed: () => Share.text('Share user',
-                  userDetailsSnap.data.userView.user.actorId, 'text/plain'),
+              onPressed: () => Share.share(
+                userDetailsSnap.data.userView.user.actorId,
+                context: context,
+              ),
             ),
           ]
         ],

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -49,7 +49,7 @@ class UserPage extends HookWidget {
             SendMessageButton(userDetailsSnap.data.userView.user),
             IconButton(
               icon: const Icon(Icons.share),
-              onPressed: () => Share.share(
+              onPressed: () => share(
                 userDetailsSnap.data.userView.user.actorId,
                 context: context,
               ),

--- a/lib/util/share.dart
+++ b/lib/util/share.dart
@@ -1,29 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:share/share.dart' as flutter_share;
+import 'package:share/share.dart';
 
 /// A `package:share` wrapper that fallbacks to copying contents to the clipboard
 /// on platforms that do not support native sharing
-abstract class Share {
-  static Future<void> share(
-    String text, {
-    String subject,
-    Rect sharePositionOrigin,
-    @required BuildContext context,
-  }) async {
-    assert(context != null);
+Future<void> share(
+  String text, {
+  String subject,
+  Rect sharePositionOrigin,
+  @required BuildContext context,
+}) async {
+  assert(context != null);
 
-    try {
-      return await flutter_share.Share.share(
-        text,
-        subject: subject,
-        sharePositionOrigin: sharePositionOrigin,
-      );
-    } on MissingPluginException {
-      await Clipboard.setData(ClipboardData(text: text));
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Copied data to clipboard!')),
-      );
-    }
+  try {
+    return await Share.share(
+      text,
+      subject: subject,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  } on MissingPluginException {
+    await Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Copied data to clipboard!')),
+    );
   }
 }

--- a/lib/util/share.dart
+++ b/lib/util/share.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share/share.dart' as flutter_share;
+
+/// A `package:share` wrapper that fallbacks to copying contents to the clipboard
+/// on platforms that do not support native sharing
+abstract class Share {
+  static Future<void> share(
+    String text, {
+    String subject,
+    Rect sharePositionOrigin,
+    @required BuildContext context,
+  }) async {
+    assert(context != null);
+
+    try {
+      return await flutter_share.Share.share(
+        text,
+        subject: subject,
+        sharePositionOrigin: sharePositionOrigin,
+      );
+    } on MissingPluginException {
+      await Clipboard.setData(ClipboardData(text: text));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Copied data to clipboard!')),
+      );
+    }
+  }
+}

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -1,4 +1,3 @@
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -16,6 +15,7 @@ import '../util/extensions/api.dart';
 import '../util/extensions/datetime.dart';
 import '../util/goto.dart';
 import '../util/intl.dart';
+import '../util/share.dart';
 import '../util/text_color.dart';
 import 'avatar.dart';
 import 'bottom_modal.dart';
@@ -149,14 +149,12 @@ class CommentWidget extends HookWidget {
             ListTile(
               leading: const Icon(Icons.share),
               title: const Text('Share url'),
-              onTap: () => Share.text(
-                  'Share comment url', com.comment.link, 'text/plain'),
+              onTap: () => Share.share(com.comment.link, context: context),
             ),
             ListTile(
               leading: const Icon(Icons.share),
               title: const Text('Share text'),
-              onTap: () => Share.text(
-                  'Share comment text', com.comment.content, 'text/plain'),
+              onTap: () => Share.share(com.comment.content, context: context),
             ),
             ListTile(
               leading:

--- a/lib/widgets/comment.dart
+++ b/lib/widgets/comment.dart
@@ -149,12 +149,12 @@ class CommentWidget extends HookWidget {
             ListTile(
               leading: const Icon(Icons.share),
               title: const Text('Share url'),
-              onTap: () => Share.share(com.comment.link, context: context),
+              onTap: () => share(com.comment.link, context: context),
             ),
             ListTile(
               leading: const Icon(Icons.share),
               title: const Text('Share text'),
-              onTap: () => Share.share(com.comment.content, context: context),
+              onTap: () => share(com.comment.content, context: context),
             ),
             ListTile(
               leading:

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -384,8 +384,7 @@ class PostWidget extends HookWidget {
               if (!fullPost)
                 IconButton(
                   icon: const Icon(Icons.share),
-                  onPressed: () =>
-                      Share.share(post.post.apId, context: context),
+                  onPressed: () => share(post.post.apId, context: context),
                 ),
               if (!fullPost) SavePostButton(post),
               _Voting(post),

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:esys_flutter_share/esys_flutter_share.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -18,6 +17,7 @@ import '../util/extensions/api.dart';
 import '../util/extensions/datetime.dart';
 import '../util/goto.dart';
 import '../util/more_icon.dart';
+import '../util/share.dart';
 import 'avatar.dart';
 import 'bottom_modal.dart';
 import 'fullscreenable_image.dart';
@@ -384,9 +384,9 @@ class PostWidget extends HookWidget {
               if (!fullPost)
                 IconButton(
                   icon: const Icon(Icons.share),
-                  onPressed: () => Share.text(
-                      'Share post url', post.post.apId, 'text/plain'),
-                ), // TODO: find a way to mark it as url
+                  onPressed: () =>
+                      Share.share(post.post.apId, context: context),
+                ),
               if (!fullPost) SavePostButton(post),
               _Voting(post),
             ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,13 +190,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  esys_flutter_share:
-    dependency: "direct main"
-    description:
-      name: esys_flutter_share
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -630,6 +623,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.25.0"
+  share:
+    dependency: "direct main"
+    description:
+      name: share
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -888,5 +888,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.22.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   modal_bottom_sheet: ^1.0.0+1
 
   # native
-  esys_flutter_share: ^1.0.2
+  share: ^2.0.1
   url_launcher: ^5.5.1
   shared_preferences: ">=0.5.0 <2.0.0"
   package_info: ^0.4.3


### PR DESCRIPTION
`esys_flutter_share` hasn't been updated in 2 years, `share` is the 'official' package with support for null safety 