### PR TITLE
Add editing post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Added
+
+- Editing posts
+
+### Fixed
+
+- Fixed bug where creating post would crash after uploading a picture
+
 ## v0.4.2 - 2021-04-12
 
 ### Changed

--- a/lib/pages/create_post.dart
+++ b/lib/pages/create_post.dart
@@ -317,7 +317,7 @@ class CreatePostPage extends HookWidget {
           padding: const EdgeInsets.all(5),
           children: [
             instanceDropdown,
-            communitiesDropdown,
+            if (!_isEdit) communitiesDropdown,
             url,
             title,
             body,

--- a/lib/pages/create_post.dart
+++ b/lib/pages/create_post.dart
@@ -15,8 +15,8 @@ import '../util/extensions/api.dart';
 import '../util/extensions/spaced.dart';
 import '../util/goto.dart';
 import '../util/pictrs.dart';
+import '../widgets/editor.dart';
 import '../widgets/markdown_mode_icon.dart';
-import '../widgets/markdown_text.dart';
 import '../widgets/radio_picker.dart';
 import 'full_post.dart';
 
@@ -292,28 +292,14 @@ class CreatePostPage extends HookWidget {
       decoration: InputDecoration(labelText: L10n.of(context)!.title),
     );
 
-    final body = IndexedStack(
-      index: showFancy.value ? 1 : 0,
-      children: [
-        TextField(
-          controller: bodyController,
-          focusNode: bodyFocusNode,
-          keyboardType: TextInputType.multiline,
-          textCapitalization: TextCapitalization.sentences,
-          onSubmitted: (_) =>
-              delayed.pending ? () {} : loggedInAction(handleSubmit),
-          maxLines: null,
-          minLines: 5,
-          decoration: InputDecoration(labelText: L10n.of(context)!.body),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(16),
-          child: MarkdownText(
-            bodyController.text,
-            instanceHost: selectedInstance.value,
-          ),
-        ),
-      ],
+    final body = Editor(
+      controller: bodyController,
+      focusNode: bodyFocusNode,
+      onSubmitted: (_) =>
+          delayed.pending ? () {} : loggedInAction(handleSubmit),
+      labelText: L10n.of(context)!.body,
+      instanceHost: selectedInstance.value,
+      fancy: showFancy.value,
     );
 
     return Scaffold(

--- a/lib/pages/full_post.dart
+++ b/lib/pages/full_post.dart
@@ -109,8 +109,13 @@ class FullPostPage extends HookWidget {
             IconButton(icon: const Icon(Icons.share), onPressed: sharePost),
             SavePostButton(post),
             IconButton(
-                icon: Icon(moreIcon),
-                onPressed: () => PostWidget.showMoreMenu(context, post)),
+              icon: Icon(moreIcon),
+              onPressed: () => PostWidget.showMoreMenu(
+                context: context,
+                post: post,
+                fullPost: true,
+              ),
+            ),
           ],
         ),
         floatingActionButton: post.post.locked

--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'markdown_text.dart';
+
+/// A text field with added functionality for ease of editing
+class Editor extends HookWidget {
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onSubmitted;
+  final int? minLines;
+  final String? labelText;
+  final bool autofocus;
+
+  /// Whether the editor should be preview the contents
+  final bool fancy;
+  final String instanceHost;
+
+  const Editor({
+    Key? key,
+    this.controller,
+    this.focusNode,
+    this.onSubmitted,
+    this.minLines = 5,
+    this.labelText,
+    this.fancy = false,
+    required this.instanceHost,
+    this.autofocus = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultController = useTextEditingController();
+    final actualController = controller ?? defaultController;
+
+    if (fancy) {
+      return Padding(
+        padding: const EdgeInsets.all(8),
+        child: MarkdownText(
+          actualController.text,
+          instanceHost: instanceHost,
+        ),
+      );
+    }
+
+    return TextField(
+      controller: actualController,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      keyboardType: TextInputType.multiline,
+      textCapitalization: TextCapitalization.sentences,
+      onSubmitted: onSubmitted,
+      maxLines: null,
+      minLines: minLines,
+      decoration: InputDecoration(labelText: labelText),
+    );
+  }
+}

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -63,7 +63,11 @@ class PostWidget extends HookWidget {
 
   // == ACTIONS ==
 
-  static void showMoreMenu(BuildContext context, PostView post) {
+  static void showMoreMenu({
+    required BuildContext context,
+    required PostView post,
+    bool fullPost = false,
+  }) {
     final isMine = context
             .read<AccountsStore>()
             .defaultUserDataFor(post.instanceHost)
@@ -97,11 +101,26 @@ class PostWidget extends HookWidget {
             ListTile(
               leading: const Icon(Icons.edit),
               title: const Text('Edit'),
-              onTap: () {
-                showCupertinoModalPopup(
+              onTap: () async {
+                final postView = await showCupertinoModalPopup<PostView>(
                   context: context,
                   builder: (_) => CreatePostPage.edit(post.post),
                 );
+
+                if (postView != null) {
+                  Navigator.of(context).pop();
+                  if (fullPost) {
+                    await goToReplace(
+                      context,
+                      (_) => FullPostPage.fromPostView(postView),
+                    );
+                  } else {
+                    await goTo(
+                      context,
+                      (_) => FullPostPage.fromPostView(postView),
+                    );
+                  }
+                }
               },
             ),
         ],
@@ -247,7 +266,8 @@ class PostWidget extends HookWidget {
                     Column(
                       children: [
                         IconButton(
-                          onPressed: () => showMoreMenu(context, post),
+                          onPressed: () =>
+                              showMoreMenu(context: context, post: post),
                           icon: Icon(moreIcon),
                           padding: const EdgeInsets.all(0),
                           visualDensity: VisualDensity.compact,

--- a/lib/widgets/post.dart
+++ b/lib/widgets/post.dart
@@ -5,12 +5,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:intl/intl.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
 
 import '../hooks/delayed_loading.dart';
 import '../hooks/logged_in_action.dart';
 import '../l10n/l10n.dart';
+import '../pages/create_post.dart';
 import '../pages/full_post.dart';
+import '../stores/accounts_store.dart';
 import '../url_launcher.dart';
 import '../util/cleanup_url.dart';
 import '../util/extensions/api.dart';
@@ -61,6 +64,12 @@ class PostWidget extends HookWidget {
   // == ACTIONS ==
 
   static void showMoreMenu(BuildContext context, PostView post) {
+    final isMine = context
+            .read<AccountsStore>()
+            .defaultUserDataFor(post.instanceHost)
+            ?.userId ==
+        post.creator.id;
+
     showBottomModal(
       context: context,
       builder: (context) => Column(
@@ -84,6 +93,17 @@ class PostWidget extends HookWidget {
               });
             },
           ),
+          if (isMine)
+            ListTile(
+              leading: const Icon(Icons.edit),
+              title: const Text('Edit'),
+              onTap: () {
+                showCupertinoModalPopup(
+                  context: context,
+                  builder: (_) => CreatePostPage.edit(post.post),
+                );
+              },
+            ),
         ],
       ),
     );

--- a/lib/widgets/radio_picker.dart
+++ b/lib/widgets/radio_picker.dart
@@ -14,7 +14,7 @@ class RadioPicker<T> extends StatelessWidget {
 
   /// custom button builder. When null, an OutlinedButton is used
   final Widget Function(
-          BuildContext context, String displayValue, VoidCallback onPressed)?
+          BuildContext context, String displayValue, VoidCallback? onPressed)?
       buttonBuilder;
 
   final Widget? trailing;
@@ -71,6 +71,10 @@ class RadioPicker<T> extends StatelessWidget {
       }
     }
 
-    return buttonBuilder(context, mapValueToString(groupValue), onPressed);
+    return buttonBuilder(
+      context,
+      mapValueToString(groupValue),
+      onChanged == null ? null : onPressed,
+    );
   }
 }

--- a/lib/widgets/write_comment.dart
+++ b/lib/widgets/write_comment.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import '../hooks/delayed_loading.dart';
 import '../hooks/logged_in_action.dart';
 import '../l10n/l10n.dart';
+import 'editor.dart';
 import 'markdown_mode_icon.dart';
 import 'markdown_text.dart';
 
@@ -110,25 +111,11 @@ class WriteComment extends HookWidget {
             ),
           ),
           const Divider(),
-          IndexedStack(
-            index: showFancy.value ? 1 : 0,
-            children: [
-              TextField(
-                controller: controller,
-                keyboardType: TextInputType.multiline,
-                textCapitalization: TextCapitalization.sentences,
-                autofocus: true,
-                minLines: 5,
-                maxLines: null,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: MarkdownText(
-                  controller.text,
-                  instanceHost: post.instanceHost,
-                ),
-              )
-            ],
+          Editor(
+            instanceHost: post.instanceHost,
+            controller: controller,
+            autofocus: true,
+            fancy: showFancy.value,
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,


### PR DESCRIPTION

https://user-images.githubusercontent.com/29288116/115127742-30c70100-9fd9-11eb-96fe-ae0edb7a6b06.mp4

The experience can get weird when going back after an edit (see screencast). It remembers the previous version. This is because the posts are not edited in place. I don't think we can easily implement this without a bigger restructure of the post/create post pages. @krawieck decide whether this is acceptable and we change it together with a create post redesign (which is needed anyways), or change it now to work in place. 